### PR TITLE
installation.md: include missing requirements

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -17,12 +17,18 @@ lang: en-US
 PHP >= 7.4.0
 BCMath PHP Extension
 Ctype PHP Extension
+cURL PHP Extension
+DOM PHP Extension
+Filter PHP Extension
+Iconv PHP Extension
 JSON PHP Extension
 Mbstring PHP Extension
 OpenSSL PHP Extension
 PDO PHP Extension
+Session PHP Extension
 Tokenizer PHP Extension
 XML PHP Extension
+ZIP PHP Extension
 ```
 
 ### Step 1 : Download


### PR DESCRIPTION
Going through the process of running and installing `crater` I had several crashes due to missing `php` dependencies. I thought it would be best to document these.